### PR TITLE
clean: depute overview

### DIFF
--- a/app/depute/[slug]/ActeurStatSectionClient.tsx
+++ b/app/depute/[slug]/ActeurStatSectionClient.tsx
@@ -29,11 +29,11 @@ const periodes: StatsPeriode[] = [
 ];
 
 const quantilesSentences = [
-  "Dans les 20% moins actifs",
-  "Dans les 40% moins actifs",
-  "Dans les 60% moins actifs",
-  "Dans les 40% plus actifs",
-  "Dans les 20% plus actifs",
+  "Dans les 20% les moins actifs",
+  "Dans les 40% les moins actifs",
+  "Dans les 60% les plus actifs",
+  "Dans les 40% les plus actifs",
+  "Dans les 20% les plus actifs",
 ];
 
 const baselineTypeToInfo: Record<string, string> = {
@@ -54,17 +54,33 @@ const MetriqueCard = (props: Stats & { valeurDepute: number }) => {
   );
 
   return (
-    <Card key={props.id}>
+    <Card
+      key={props.id}
+      variant="outlined"
+      sx={{ borderRadius: 3, borderColor: "#e0e0e0", boxShadow: "none" }}
+    >
       <CardContent>
-        <Typography variant="h1" sx={{ textAlign: "right" }}>
+        <Typography
+          variant="h1"
+          fontWeight="medium"
+          sx={{ textAlign: "right", lineHeight: 1, mb: 0 }}
+        >
           {props.valeurDepute}
         </Typography>
-        <Stack direction="row">
-          <InfoDialogIcon
-            category="depute"
-            item={baselineTypeToInfo[props.mesure]}
-          />
-          <Typography variant="body1" sx={{ textAlign: "right", flexGrow: 1 }}>
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          justifyContent="flex-end"
+          sx={{ mb: 1.5 }}
+        >
+          <Box sx={{ display: "flex", flexShrink: 0 }}>
+            <InfoDialogIcon
+              category="depute"
+              item={baselineTypeToInfo[props.mesure]}
+            />
+          </Box>
+          <Typography variant="caption" sx={{ textAlign: "right" }}>
             {infoDialogContents.depute[baselineTypeToInfo[props.mesure]]
               ?.translation ?? props.mesure}
           </Typography>
@@ -76,7 +92,8 @@ const MetriqueCard = (props: Stats & { valeurDepute: number }) => {
             display: "flex",
             flexDirection: "row",
             alignItems: "stretch",
-            gap: 2,
+            gap: 1,
+            mb: 0.5,
           }}
         >
           {quantiles.map((q, index) => {
@@ -109,6 +126,7 @@ const MetriqueCard = (props: Stats & { valeurDepute: number }) => {
                       position: "absolute",
                       bottom: 0,
                       left: 0,
+                      borderRadius: 1,
                     }}
                   />
                 </Box>
@@ -163,19 +181,61 @@ export function ActeurStatSectionClient({
 
   return (
     <div>
-      <Select
-        value={periode}
-        onChange={(event) => setPeriode(event.target.value)}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          width: "100%",
+          mb: 3,
+          mt: 5,
+        }}
       >
-        <MenuItem value="LEGISLATURE">Legislature</MenuItem>
-        <MenuItem value="LAST_YEAR">Un an</MenuItem>
-        <MenuItem value="LAST_SIX_MONTHS">Six mois</MenuItem>
-      </Select>
+        <Typography variant="subtitle1" fontWeight={"bold"} component="h2">
+          Statistiques d&apos;activité
+        </Typography>
+        <Select
+          value={periode}
+          onChange={(event) => setPeriode(event.target.value)}
+          disableUnderline
+          variant="standard"
+          sx={{
+            minWidth: 180,
+            backgroundColor: "white",
+            borderRadius: "50px",
+            fontSize: "0.9rem",
+            color: "#666",
+            "& .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#e0e0e0",
+            },
+            "&:hover .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#ccc",
+            },
+            "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#aaa",
+              borderWidth: "1px",
+            },
+            "& .MuiSelect-select": {
+              py: 1,
+              px: 2,
+              backgroundColor: "transparent !important",
+            },
+            "& .MuiSvgIcon-root": {
+              right: "12px",
+              color: "#888",
+            },
+          }}
+        >
+          <MenuItem value="LEGISLATURE">Toute la législature</MenuItem>
+          <MenuItem value="LAST_YEAR">12 derniers mois</MenuItem>
+          <MenuItem value="LAST_SIX_MONTHS">6 derniers mois</MenuItem>
+        </Select>
+      </Box>
 
       <Box
         sx={{
           display: "grid",
-          gap: 1,
+          gap: 2,
           gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
           mt: 2,
         }}

--- a/app/depute/[slug]/Contacts.tsx
+++ b/app/depute/[slug]/Contacts.tsx
@@ -73,14 +73,14 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
   );
 
   return (
-    <Paper sx={{ p: 2, bgcolor: "grey.50", width: 300 }} elevation={0}>
+    <Paper sx={{ p: 2, bgcolor: "grey.100", width: 300, borderRadius: "16px" }} elevation={0}>
       <Stack direction="column" spacing={1}>
-        <Typography variant="subtitle1">Contacts</Typography>
+        <Typography variant="subtitle1" fontWeight="bold">Contacts</Typography>
 
         {/* Adresses physique */}
         {postalAdresses.length > 0 && (
           <Box>
-            <Typography variant="body2" fontWeight="light">
+            <Typography variant="body2" fontWeight="light" color="grey.600">
               Courier
             </Typography>
             <List>
@@ -103,10 +103,10 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
                       mb: 1,
                     }}
                   >
-                    <Typography variant="body2" fontWeight="light">
+                    <Typography variant="body2" fontWeight="medium">
                       {intitule}
                     </Typography>
-                    <Typography variant="caption">
+                    <Typography variant="body2" fontWeight="medium">
                       {numeroRue} {nomRue}
                       <br />
                       {complementAdresse}
@@ -122,7 +122,7 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
 
         {mailAdresses.length > 0 && (
           <Box>
-            <Typography variant="body2" fontWeight="light">
+            <Typography variant="body2" fontWeight="light" color="grey.600">
               Email
             </Typography>
             <List>
@@ -136,7 +136,7 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
                     mb: 1,
                   }}
                 >
-                  <Typography variant="caption" fontWeight="light">
+                  <Typography variant="body2" fontWeight="medium">
                     {valElec}
                   </Typography>
                 </ListItem>
@@ -147,7 +147,7 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
 
         {phoneAdresses.length > 0 && (
           <Box>
-            <Typography variant="body2" fontWeight="light">
+            <Typography variant="body2" fontWeight="light" color="grey.600">
               Téléphone
             </Typography>
             <List>
@@ -161,7 +161,7 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
                     mb: 1,
                   }}
                 >
-                  <Typography variant="caption" fontWeight="light">
+                  <Typography variant="body2" fontWeight="medium">
                     {valElec}
                   </Typography>
                 </ListItem>
@@ -172,7 +172,7 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
 
         {internetAdresses.length > 0 && (
           <Box>
-            <Typography variant="body2" fontWeight="light">
+            <Typography variant="body2" fontWeight="light" color="grey.600">
               Internet
             </Typography>
             <List>
@@ -202,8 +202,8 @@ export default async function Contacts({ acteurUid }: { acteurUid: string }) {
                     </ListItemIcon>
 
                     <Typography
-                      variant="caption"
-                      fontWeight="light"
+                      variant="body2"
+                      fontWeight="medium"
                       component="a"
                       target="_blank"
                       href={href}

--- a/app/depute/[slug]/InfoPersonelles.tsx
+++ b/app/depute/[slug]/InfoPersonelles.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Paper, Stack, Typography } from "@mui/material";
+import { Box, Paper, Stack, Typography } from "@mui/material";
 import { Acteur } from "@prisma/client";
 import { getActeurMandats } from "@/data/getActeurMandats";
 import InfoDialogIcon from "@/components/InfoDialog/InfoDialogIcon";
@@ -38,24 +38,30 @@ export default async function InfoPersonelles({
     ).getFullYear() - 1970;
 
   return (
-    <Paper sx={{ p: 2, bgcolor: "grey.50", width: 300 }} elevation={0}>
+    <Paper
+      sx={{ p: 2, bgcolor: "grey.100", borderRadius: "16px", width: "100%" }}
+      elevation={0}
+    >
       <Stack direction="column" spacing={2}>
-        <Typography variant="subtitle1">Informations personelles</Typography>
-
+        <Typography variant="subtitle1" fontWeight={"bold"}>
+          Fiche d&apos;identité
+        </Typography>
         {dernierMandatDepute === undefined ? (
           <div>
             <Typography variant="body2" fontWeight="light">
-              Debut de mandat
+              Début de mandat
             </Typography>
-            <Typography variant="body2">Pas de mandat de député·e·s</Typography>
+            <Typography variant="body2" fontWeight="medium">
+              Pas de mandat de député·e
+            </Typography>
           </div>
         ) : (
           <React.Fragment>
             <div>
-              <Typography variant="body2" fontWeight="light">
-                Debut de mandat
+              <Typography variant="body2" fontWeight="light" color="grey.600">
+                Début de mandat
               </Typography>
-              <Typography variant="body2">
+              <Typography variant="body2" fontWeight="medium">
                 Le{" "}
                 {new Date(dernierMandatDepute?.dateDebut).toLocaleDateString(
                   "fr-FR",
@@ -67,10 +73,10 @@ export default async function InfoPersonelles({
 
             {dernierMandatDepute?.dateFin !== null ? (
               <div>
-                <Typography variant="body2" fontWeight="light">
+                <Typography variant="body2" fontWeight="light" color="grey.600">
                   Fin de mandat
                 </Typography>
-                <Typography variant="body2">
+                <Typography variant="body2" fontWeight="medium">
                   {`Le ${new Date(
                     dernierMandatDepute?.dateFin
                   ).toLocaleDateString("fr-FR", {
@@ -85,43 +91,128 @@ export default async function InfoPersonelles({
         )}
 
         <div>
-          <Typography variant="body2" fontWeight="light">
-            Group politique <InfoDialogIcon category="organe" item="GP" />
+          <Typography
+            variant="body2"
+            fontWeight="light"
+            color="grey.600"
+            sx={{
+              lineHeight: 1,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            Groupe politique
+            <Box
+              component="span"
+              sx={{
+                display: "inline-flex",
+                ml: 0.5,
+                verticalAlign: "text-bottom",
+                "& button": {
+                  p: 0,
+                  minWidth: 0,
+                  height: "auto",
+                  lineHeight: 0,
+                },
+                "& svg": {
+                  fontSize: "1rem",
+                  color: "grey.400",
+                },
+              }}
+            >
+              <InfoDialogIcon category="organe" item="GP" />
+            </Box>
           </Typography>
-          <Typography variant="body2">
+          <Typography variant="body2" fontWeight="medium">
             {derniergroupeParlementaire &&
             derniergroupeParlementaire.dateFin === null
-              ? derniergroupeParlementaire.organeRef?.libelleAbrege
+              ? derniergroupeParlementaire.organeRef?.libelle
               : "-"}
           </Typography>
         </div>
 
         <div>
-          <Typography variant="body2" fontWeight="light">
-            Partis politique <InfoDialogIcon category="organe" item="PARPOL" />
+          <Typography
+            variant="body2"
+            fontWeight="light"
+            color="grey.600"
+            sx={{
+              lineHeight: 1,
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            Parti politique
+            <Box
+              component="span"
+              sx={{
+                display: "inline-flex",
+                ml: 0.5,
+                verticalAlign: "text-bottom",
+                "& button": {
+                  p: 0,
+                  minWidth: 0,
+                  height: "auto",
+                  lineHeight: 0,
+                },
+                "& svg": {
+                  fontSize: "1rem",
+                  color: "grey.400",
+                },
+              }}
+            >
+              <InfoDialogIcon category="organe" item="PARPOL" />
+            </Box>
           </Typography>
-          <Typography variant="body2">
+          <Typography variant="body2" fontWeight="medium">
             {dernierPartisPolitique && dernierPartisPolitique.dateFin === null
-              ? dernierPartisPolitique.organeRef?.libelleAbrege
+              ? dernierPartisPolitique.organeRef?.libelle
               : "-"}
           </Typography>
         </div>
 
         <div>
-          <Typography variant="body2" fontWeight="light">
+          <Typography variant="body2" fontWeight="light" color="grey.600">
             Date de naissance
           </Typography>
-          <Typography variant="body2">
+          <Typography variant="body2" fontWeight="medium">
             Le {dateNais && new Date(dateNais).toLocaleDateString("fr-FR")} (
             {age} ans) à {villeNais}
           </Typography>
         </div>
 
         <div>
-          <Typography variant="body2" fontWeight="light">
-            Profession <InfoDialogIcon category="depute" item="profession" />
+          <Typography
+            variant="body2"
+            fontWeight="light"
+            color="grey.600"
+            sx={{ lineHeight: 1, display: "flex", alignItems: "center" }}
+          >
+            Profession
+            <Box
+              component="span"
+              sx={{
+                display: "inline-flex",
+                ml: 0.5,
+                verticalAlign: "text-bottom",
+                "& button": {
+                  p: 0,
+                  minWidth: 0,
+                  height: "auto",
+                  lineHeight: 0,
+                },
+                "& svg": {
+                  fontSize: "1rem",
+                  color: "grey.400",
+                },
+              }}
+            >
+              <InfoDialogIcon category="depute" item="profession" />
+            </Box>
           </Typography>
-          <Typography variant="body2">{profession}</Typography>
+          <Typography variant="body2" fontWeight="medium">
+            {profession}
+          </Typography>
         </div>
       </Stack>
     </Paper>

--- a/app/depute/[slug]/Mandats.tsx
+++ b/app/depute/[slug]/Mandats.tsx
@@ -50,17 +50,35 @@ export default async function Mandats({ acteurUid }: { acteurUid: string }) {
   );
 
   return (
-    <Paper sx={{ p: 2, bgcolor: "grey.50", width: 300 }} elevation={0}>
+    <Paper sx={{ p: 2, bgcolor: "grey.100", width: 300, borderRadius: "16px" }} elevation={0}>
       <Stack direction="column" spacing={2}>
-        <Typography variant="subtitle1">Responsabilités</Typography>
+        <Typography variant="subtitle1" fontWeight={"bold"}>Responsabilités</Typography>
 
         {types.map((type) => (
           <Box key={type}>
-            <Typography variant="body2" fontWeight="light">
+            <Typography variant="body2" fontWeight="light" color="grey.600">
               {organeTranslations[type] ?? type}{" "}
-              <InfoDialogIcon category="organe" item={type} />
+              <Box component="span" sx={{ 
+                display: 'inline-flex', 
+                ml: 0.5,
+                verticalAlign: 'text-bottom',
+                '& button': { 
+                  p: 0, 
+                  minWidth: 0, 
+                  height: 'auto',
+                  lineHeight: 0
+                },
+                '& svg': { 
+                  fontSize: '1rem',
+                  color: 'grey.400' 
+                }
+              }}>
+                <InfoDialogIcon category="organe" item={type} />
+              </Box>
+
+              
             </Typography>
-            <List>
+            <List sx={{ listStyleType: 'disc', pl: 2.5 }}>
               {mandatsPerType[type]
                 .filter(({ libQualiteSex, organeRefUid }) => {
                   if (libQualiteSex !== "Membre") {
@@ -74,8 +92,10 @@ export default async function Mandats({ acteurUid }: { acteurUid: string }) {
                   );
                 })
                 .map(({ libelle, libQualiteSex }) => (
-                  <ListItem key={libelle} disablePadding>
-                    <Typography variant="body2">
+                  <ListItem key={libelle} 
+                      disablePadding 
+                      sx={{ display: 'list-item', mb: 0.5 }}>
+                    <Typography variant="body2" fontWeight="medium">
                       {libelle}
                       {libQualiteSex && ` (${libQualiteSex})`}
                     </Typography>

--- a/app/depute/[slug]/Tabs.tsx
+++ b/app/depute/[slug]/Tabs.tsx
@@ -10,7 +10,29 @@ export default function DeputeTabs({ slug }: { slug: string }) {
   const segment = useSelectedLayoutSegment();
 
   return (
-    <Tabs value={segment ?? "activites"} variant="scrollable">
+    <Tabs value={segment ?? "activites"} variant="scrollable" sx={{
+        minHeight: 40,
+        borderBottom: 1,
+        borderColor: 'divider',
+        '& .MuiTabs-indicator': {
+          backgroundColor: 'black',
+          height: 2,
+        },
+        '& .MuiTab-root': {
+          textTransform: 'uppercase',
+          minHeight: 40,
+          minWidth: 'auto',
+          px: 3,
+          fontWeight: 600,
+          fontSize: '0.75rem',
+          letterSpacing: '0.15em',
+          color: 'text.secondary',
+          fontFamily: 'inherit',
+        },
+        '& .Mui-selected': {
+          color: 'black !important',
+        }
+      }}>
       <Tab
         value="activites"
         label="Activités"

--- a/app/depute/[slug]/WeeklyActivity/WeeklyActivityChart.tsx
+++ b/app/depute/[slug]/WeeklyActivity/WeeklyActivityChart.tsx
@@ -23,7 +23,7 @@ import Typography from "@mui/material/Typography";
 import { StatistiqueHebdomadaire } from "@prisma/client";
 
 const seriesConfig: Record<
-  "commission" | "hemicicle",
+  "commission" | "hemicycle",
   (BarSeriesType | LineSeriesType)[]
 > = {
   commission: [
@@ -32,7 +32,7 @@ const seriesConfig: Record<
       dataKey: "presenceCommissionMedian",
       type: "line",
       stack: "mediane",
-      color: "red",
+      color: "darkgreen",
       curve: "step",
       label: "Médiane des députés",
     },
@@ -41,25 +41,25 @@ const seriesConfig: Record<
       dataKey: "presenceCommission",
       type: "bar",
       stack: "depute",
-      color: "orange",
+      color: "lightgreen",
       label: "Présences en commissions",
     },
   ],
-  hemicicle: [
+  hemicycle: [
     {
-      id: "hemicicle-depute",
+      id: "hemicycle-depute",
       dataKey: "debat",
       type: "bar",
       stack: "depute",
-      color: "blue",
-      label: "Présence détectée en hémicicle",
+      color: "lightblue",
+      label: "Présence détectée en hémicycle",
     },
     {
-      id: "hemicicle-stats",
+      id: "hemicycle-stats",
       dataKey: "debatMedian",
       type: "line",
       stack: "mediane",
-      color: "darkblue",
+      color: "blue",
       curve: "step",
       label: "Mediane des députés",
     },
@@ -73,7 +73,7 @@ export default function WeeklyActivityChart(props: {
   presenceDetecteeMediane: StatistiqueHebdomadaire[];
   presenceCommisionMax: StatistiqueHebdomadaire[];
   presenceCommisionMediane: StatistiqueHebdomadaire[];
-  activityType: "commission" | "hemicicle";
+  activityType: "commission" | "hemicycle";
 }) {
   const { presenceDetecteeDataset, vacances } = useAgregateWeeklyStats(props);
   return (
@@ -97,11 +97,11 @@ export default function WeeklyActivityChart(props: {
             })}`;
           },
           tickInterval: (_, index) => index % 10 === 5,
-          // @ts-ignore
-          categoryGapRatio: 0,
+          categoryGapRatio: 0.1,
         },
       ]}
-      margin={{bottom: 0}}
+      yAxis={[{ width: 30 }]}
+      margin={{ left: 0, right: 0, top: 20, bottom: 5 }}
       series={seriesConfig[props.activityType]}
     >
       <Box
@@ -111,7 +111,7 @@ export default function WeeklyActivityChart(props: {
           flexDirection: "column",
           gap: 0,
           alignItems: "center",
-          mb: 4
+          mb: 4,
         }}
       >
         <ChartsSurface>

--- a/app/depute/[slug]/WeeklyActivity/WeeklyActivitySectionClient.tsx
+++ b/app/depute/[slug]/WeeklyActivity/WeeklyActivitySectionClient.tsx
@@ -14,23 +14,50 @@ export default function WeeklyActivitySectionClient(props: {
   presenceCommisionMediane: StatistiqueHebdomadaire[];
 }) {
   const [activityType, setActivityType] = React.useState<
-    "commission" | "hemicicle"
-  >("hemicicle");
+    "commission" | "hemicycle"
+  >("hemicycle");
 
   return (
     <div>
       <Stack direction="row" justifyContent="space-between">
-        <Typography variant="h4" component="h2">
+        <Typography variant="subtitle1" fontWeight="bold" component="h2">
           Présences et participations
         </Typography>
         <Select
-          variant="outlined"
           value={activityType}
           onChange={(event) =>
-            setActivityType(event.target.value as "commission" | "hemicicle")
+            setActivityType(event.target.value as "commission" | "hemicycle")
           }
+          disableUnderline
+          variant="standard"
+          sx={{
+            minWidth: 140,
+            backgroundColor: "white",
+            borderRadius: "50px",
+            fontSize: "0.9rem",
+            color: "#666",
+            "& .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#e0e0e0",
+            },
+            "&:hover .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#ccc",
+            },
+            "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+              borderColor: "#aaa",
+              borderWidth: "1px",
+            },
+            "& .MuiSelect-select": {
+              py: 1,
+              px: 2,
+              backgroundColor: "transparent !important",
+            },
+            "& .MuiSvgIcon-root": {
+              right: "12px",
+              color: "#888",
+            },
+          }}
         >
-          <MenuItem value="hemicicle">Hémicicle</MenuItem>
+          <MenuItem value="hemicycle">Hémicycle</MenuItem>
           <MenuItem value="commission">Commissions</MenuItem>
         </Select>
       </Stack>

--- a/app/depute/[slug]/layout.tsx
+++ b/app/depute/[slug]/layout.tsx
@@ -1,11 +1,73 @@
 import React from "react";
 import { Avatar, Box, Container, Stack, Typography } from "@mui/material";
-import CircleDiv from "@/icons/CircleDiv";
+import {
+  X as XIcon,
+  Facebook as FacebookIcon,
+  Language as WebsiteIcon,
+  Instagram as InstagramIcon,
+  LinkedIn as LinkedInIcon,
+} from "@mui/icons-material";
+import Link from "next/link";
 import Mandats from "./Mandats";
 import Contacts from "./Contacts";
 import Tabs from "./Tabs";
 import InfoPersonelles from "./InfoPersonelles";
 import { getActeurBySlug } from "@/data/getActeurBySlug";
+import { getActeurAdressesElectroniques } from "@/data/getActeurContacts";
+
+const SocialLink = ({
+  Icon,
+  href,
+}: {
+  Icon: React.ElementType;
+  href: string;
+}) => (
+  <Box
+    component="a"
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    sx={{
+      width: 44,
+      height: 44,
+      borderRadius: "50%",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      bgcolor: "white",
+      boxShadow: "0px 2px 8px rgba(0,0,0,0.08)",
+      border: "1px solid #f0f0f0",
+      color: "#1A1A1B",
+      transition: "all 0.2s",
+      "&:hover": {
+        transform: "scale(1.1)",
+        color: "#000",
+      },
+    }}
+  >
+    <Icon sx={{ fontSize: 20 }} />
+  </Box>
+);
+
+const contactButtonStyle = {
+  bgcolor: "#1A1A1B",
+  color: "white",
+  px: 3.5,
+  py: 1.2,
+  borderRadius: "30px",
+  fontSize: "12px",
+  fontWeight: "bold",
+  textTransform: "uppercase",
+  letterSpacing: "0.1em",
+  cursor: "pointer",
+  textDecoration: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  whiteSpace: "nowrap",
+  transition: "background-color 0.2s",
+  "&:hover": { bgcolor: "#333" },
+};
 
 export default async function Page({
   children,
@@ -18,17 +80,62 @@ export default async function Page({
   const depute = await getActeurBySlug(slug);
 
   if (depute === null) {
-    return <p>Deputé Not Found</p>;
+    return <p>Deputé non trouvé</p>;
   }
+
+  const adressesElectroniques = await getActeurAdressesElectroniques(
+    depute.uid
+  );
+
+  const twitter = adressesElectroniques.find(
+    (c) => c.typeLibelle === "Twitter"
+  )?.valElec;
+  const facebook = adressesElectroniques.find(
+    (c) => c.typeLibelle === "Facebook"
+  )?.valElec;
+  const instagram = adressesElectroniques.find(
+    (c) => c.typeLibelle === "Instagram"
+  )?.valElec;
+  const linkedin = adressesElectroniques.find(
+    (c) => c.typeLibelle === "Linkedin"
+  )?.valElec;
+  const website = adressesElectroniques.find(
+    (c) => c.typeLibelle === "Site internet"
+  )?.valElec;
+
+  const emails = adressesElectroniques.filter((c) => c.typeLibelle === "Mèl");
+  const emailAN = emails.find((e) =>
+    e.valElec?.includes("assemblee-nationale.fr")
+  )?.valElec;
+  const email = emailAN || emails[0]?.valElec;
 
   const circonscription = depute.mandatPrincipal;
 
   return (
-    <Box sx={{ maxWidth: "1024px", width: "100%", mx: "auto", my: 5 }}>
-      <Stack direction="row" justifyContent="space-between">
-        <Box sx={{ display: "flex", flexDirection: "row" }}>
+    <Box
+      sx={{
+        maxWidth: "1400px",
+        width: "100%",
+        mx: "auto",
+        my: 5,
+        px: { xs: 2, md: 4 },
+      }}
+    >
+      <Stack
+        direction={{ xs: "column", md: "row" }}
+        alignItems={{ xs: "flex-start", md: "center" }}
+        justifyContent="space-between"
+        spacing={{ xs: 3, md: 0 }}
+        sx={{ mb: 4 }}
+      >
+        {/* Bloc Identité (Avatar + Nom) */}
+        <Stack direction="row" alignItems="center" spacing={2}>
           <Avatar
-            sx={{ bgcolor: "grey.200", width: 100, height: 100, mr: 1 }}
+            sx={{
+              bgcolor: "grey.200",
+              width: { xs: 70, md: 90 },
+              height: { xs: 70, md: 90 },
+            }}
             alt={`${depute.prenom} ${depute.nom}`}
             src={depute.urlImage ?? ""}
           >
@@ -36,51 +143,87 @@ export default async function Page({
             {depute.nom[0]}
           </Avatar>
           <Box>
-            <Typography variant="h1" fontWeight="bold">
+            <Typography
+              variant="h3"
+              fontWeight="bold"
+              sx={{
+                color: "#1A1A1B",
+                fontSize: { xs: "1.5rem", md: "1.7rem" },
+              }}
+            >
               {depute.prenom} {depute.nom}
             </Typography>
 
             {circonscription && (
-              <Typography variant="body1" fontWeight="light">
+              <Typography
+                variant="body1"
+                fontWeight="light"
+                color="text.secondary"
+              >
+                {circonscription.numCirco}° circonscription de{" "}
                 {circonscription.departement} ({circonscription.numDepartement})
-                circonscription n°{circonscription.numCirco}
-                {circonscription.dateFin !== null && (
-                  <>
-                    <br />
-                    Fin de mandat le{" "}
-                    {new Date(circonscription.dateFin).toLocaleDateString(
-                      "fr-FR"
-                    )}
-                  </>
-                )}
               </Typography>
             )}
-
-            {depute.groupeParlementaire && (
-              // Deputes sans mandat n'ont plus d'organe associé
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "row",
-                  alignItems: "center",
-                  mt: 1,
-                }}
-              >
-                <CircleDiv
-                  color={depute.groupeParlementaire.couleurAssociee!}
-                />{" "}
-                <Typography sx={{ ml: 1 }} variant="body1" fontWeight="light">
-                  {depute.groupeParlementaire.libelle} (
-                  {depute.groupeParlementaire.libelleAbrev})
-                </Typography>
-              </Box>
-            )}
           </Box>
-        </Box>
+        </Stack>
+
+        {/* Bloc Actions (Réseaux + Contact) */}
+        <Stack
+          direction="row"
+          alignItems="center"
+          flexWrap="wrap"
+          gap={1.5}
+          sx={{ width: { xs: "100%", md: "auto" } }}
+        >
+          {website && (
+            <SocialLink Icon={WebsiteIcon} href={`https://${website}`} />
+          )}
+          {twitter && (
+            <SocialLink Icon={XIcon} href={`https://x.com/${twitter}`} />
+          )}
+          {facebook && (
+            <SocialLink
+              Icon={FacebookIcon}
+              href={`https://facebook.com/${facebook}`}
+            />
+          )}
+          {instagram && (
+            <SocialLink
+              Icon={InstagramIcon}
+              href={`https://instagram.com/${instagram}`}
+            />
+          )}
+          {linkedin && (
+            <SocialLink
+              Icon={LinkedInIcon}
+              href={`https://linkedin.com/${linkedin}`}
+            />
+          )}
+
+          {email ? (
+            <Box
+              component="a"
+              href={`mailto:${email}`}
+              sx={{ ...contactButtonStyle, ml: { md: 1 } }}
+            >
+              Contacter
+            </Box>
+          ) : (
+            <Link
+              href="#contacts"
+              style={{ textDecoration: "none", marginLeft: 8 }}
+            >
+              <Box sx={contactButtonStyle}>Contacter</Box>
+            </Link>
+          )}
+        </Stack>
       </Stack>
+
       <Container
+        disableGutters
+        maxWidth={false}
         sx={{
-          pt: 3,
+          pt: 1,
           display: "flex",
           flexDirection: {
             xs: "column",
@@ -89,12 +232,23 @@ export default async function Page({
           gap: 4,
         }}
       >
-        <Stack spacing={3} useFlexGap flex={2}>
+        {/* Colonne de Gauche (Infos) */}
+        <Stack
+          spacing={3}
+          flex={2}
+          // Force les cartes enfants (InfoPersonelles, etc.) à prendre 100% de la largeur du conteneur
+          sx={{
+            minWidth: 0,
+            width: "100%",
+            "& > *": { width: "100% !important" }, // Hack CSS pour forcer la largeur des Paper enfants qui ont width: 300
+          }}
+        >
           <InfoPersonelles acteurUid={depute.uid} depute={depute} />
           <Mandats acteurUid={depute.uid} />
           <Contacts acteurUid={depute.uid} />
         </Stack>
 
+        {/* Colonne de Droite (Tabs et Contenu principal) */}
         <Stack spacing={3} flex={5} sx={{ minWidth: 0 }}>
           <Tabs slug={slug} />
           {children}


### PR DESCRIPTION
Extracted from #52 

@FizBack J'ai modifié les couleur comme ça, pour garder une cohérence "light=depute / dark=mediane". J'ai aussi réduit un peu le gap entre le bares pour garder la séparation entre les semaines tout en ayant une impression de continuité

<img width="877" height="429" alt="image" src="https://github.com/user-attachments/assets/914cf91f-2770-4e28-8edf-b46ded9ebf3f" />
<img width="877" height="429" alt="image" src="https://github.com/user-attachments/assets/504fc5e7-6d4f-4afa-aad4-a9d93fba3414" />
