### PR TITLE
Suppression du Sommaire lorsque celui ci est vide

### DIFF
--- a/app/[legislature]/dossier/[id]/debat/[debatUid]/page.tsx
+++ b/app/[legislature]/dossier/[id]/debat/[debatUid]/page.tsx
@@ -46,25 +46,39 @@ export default async function Page({
     } as Record<string, number>
   );
 
-  return (
+  const sections = interventions.filter((p) =>
+    SUMMARY_CODES.has(p.codeGrammaire!)
+  );
+
+  const hasSummary = sections.length > 0;
+
+return (
     <>
+      { /* On n'affiche la colonne de gauche que s'il y a un sommaire associé */}
+      {hasSummary && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            gap: 24,
+            flex: 2,
+          }}
+        >
+          <DebateSummary sections={sections} />
+        </div>
+      )}
+
+      {/* On adapte le style de la colonne principale */}
       <div
         style={{
           display: "flex",
-          flexDirection: "row",
-          gap: 24,
-          flex: 2,
+          flexDirection: "column",
+          flex: 5,
+          margin: hasSummary ? "0" : "0 auto", 
+          maxWidth: hasSummary ? "none" : "750px",
+          width: "100%"
         }}
       >
-        <DebateSummary
-          // wordsCounts={wordsCounts}
-          sections={interventions.filter(
-            (p) =>
-              SUMMARY_CODES.has(p.codeGrammaire!) 
-          )}
-        />
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", flex: 5 }}>
         <DebateTranscript
           title={debat?.dateSeanceJour ?? ""}
           paragraphes={interventions}


### PR DESCRIPTION
Le sommaire ne contient généralement pas d'éléments du fait de la difficulté à sortir des éléments structurants des débats.

L'idée est ici de supprimer la barre latérale de "Sommaire" quand celle-ci est vide pour centrer le contenu.