### PR TITLE
Ajout d'un Chip pour afficher le groupe politique sur les pages députés

### DIFF
--- a/app/depute/[slug]/InfoPersonelles.tsx
+++ b/app/depute/[slug]/InfoPersonelles.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Box, Paper, Stack, Typography } from "@mui/material";
+import { Box, Chip, Paper, Stack, Typography } from "@mui/material";
 import { Acteur } from "@prisma/client";
 import { getActeurMandats } from "@/data/getActeurMandats";
 import InfoDialogIcon from "@/components/InfoDialog/InfoDialogIcon";
@@ -123,12 +123,22 @@ export default async function InfoPersonelles({
               <InfoDialogIcon category="organe" item="GP" />
             </Box>
           </Typography>
-          <Typography variant="body2" fontWeight="medium">
-            {derniergroupeParlementaire &&
-            derniergroupeParlementaire.dateFin === null
-              ? derniergroupeParlementaire.organeRef?.libelle
-              : "-"}
-          </Typography>
+          <Chip 
+              label={derniergroupeParlementaire.organeRef?.libelle}
+              size="small"
+              sx={{
+                backgroundColor: derniergroupeParlementaire.organeRef?.couleurAssociee || "#e0e0e0",
+                color: derniergroupeParlementaire.organeRef?.couleurAssociee ? "#fff" : "rgba(0, 0, 0, 0.87)",
+                fontWeight: 600,
+                fontSize: "0.8rem",
+                height: "30px",
+                mt: 0.7,
+                "& .MuiChip-label": {
+                    paddingLeft: 1.5,
+                    paddingRight: 1.5
+                }
+              }}
+            />
         </div>
 
         <div>

--- a/app/depute/[slug]/InfoPersonelles.tsx
+++ b/app/depute/[slug]/InfoPersonelles.tsx
@@ -124,7 +124,7 @@ export default async function InfoPersonelles({
             </Box>
           </Typography>
           <Chip 
-              label={derniergroupeParlementaire.organeRef?.libelle}
+              label={derniergroupeParlementaire.organeRef?.libelle ?? '-'}
               size="small"
               sx={{
                 backgroundColor: derniergroupeParlementaire.organeRef?.couleurAssociee || "#e0e0e0",


### PR DESCRIPTION
Mini modifier pour que le groupe politique d'appartenance d'un député ressorte mieux (via la création d'une Chip)