### PR TITLE
fix: gestion des debats

### DIFF
--- a/app/[legislature]/dossier/[id]/Tabs.tsx
+++ b/app/[legislature]/dossier/[id]/Tabs.tsx
@@ -6,8 +6,6 @@ import Box from "@mui/material/Box";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
-import { getDebats, ReturnedDebat } from "@/data/getDebats";
 
 export default function DossiersTabs(props: {
   legislature: string;
@@ -15,19 +13,11 @@ export default function DossiersTabs(props: {
   showDebats: boolean;
   showAmendements: boolean;
   showVotes: boolean;
+  hasDebats: boolean;
 }) {
-  const { legislature, dossierUid, showDebats, showAmendements, showVotes } =
+  const { legislature, dossierUid, showDebats, showAmendements, showVotes, hasDebats } =
     props;
   const segment = useSelectedLayoutSegment();
-
-  const { data: debats } = useQuery({
-    queryKey: ["debats", dossierUid],
-    queryFn: async () => await getDebats(dossierUid),
-  });
-
-  const debatsDisponibles = debats?.filter(
-    (compteRendu: ReturnedDebat) => compteRendu._count.paragraphes > 0,
-  );
 
   const rootPathName = `/${legislature}/dossier/${dossierUid}/`;
 
@@ -38,7 +28,7 @@ export default function DossiersTabs(props: {
       label: "Débats",
       href: `${rootPathName}debat`,
       visible: showDebats,
-      disabled: debatsDisponibles != null && debatsDisponibles.length === 0,
+      disabled: !hasDebats,
     },
     {
       value: "amendement",

--- a/app/[legislature]/dossier/[id]/dataFunctions.ts
+++ b/app/[legislature]/dossier/[id]/dataFunctions.ts
@@ -1,6 +1,16 @@
 import * as React from "react";
-import { ActeLegislatif, Dossier, Rapporteur } from "@prisma/client";
+import { ActeLegislatif, Dossier, Rapporteur, Agenda, PointOdj } from "@prisma/client";
 import { Status } from "@/components/StatusChip";
+
+// Type pour un acte avec agendaRef inclus (renvoyé par l'API avec include)
+type ActeWithAgendaRef = ActeLegislatif & {
+  agendaRef?: Agenda & { pointsOdj: PointOdj[] } | null;
+};
+
+// Type pour un dossier avec actesLegislatifs incluant agendaRef
+type DossierWithActes = Dossier & {
+  actesLegislatifs: ActeWithAgendaRef[];
+};
 
 const statusOrder = ["AN1", "SN1", "AN2", "SN2", "AN3", "SN3", "CMP", "PROM"];
 
@@ -44,4 +54,38 @@ export function getCommissionUids(
         .filter((id) => id !== null)
     )
   );
+}
+
+/**
+ * Filtre les réunions (agendaRef) des actes législatifs d'un dossier qui ont :
+ * - Un compte rendu associé (compteRenduRefUid)
+ * - Au moins un point d'ordre du jour lié au dossier et non annulé
+ * - Pas de doublons (même agenda.uid)
+ */
+export function getReunionsWithCompteRendu(dossier: DossierWithActes | null) {
+  if (!dossier) return [];
+  
+  const reunions: (Agenda & { pointsOdj: PointOdj[] })[] = [];
+  const seenAgendaUids = new Set<string>();
+
+  dossier.actesLegislatifs.forEach((acte) => {
+    if (acte.agendaRef && acte.codeActe.includes("SEANCE")) {
+      // Skip si cette réunion a déjà été ajoutée
+      if (seenAgendaUids.has(acte.agendaRef.uid)) {
+        return;
+      }
+
+      if (
+        acte.agendaRef.compteRenduRefUid &&
+        acte.agendaRef.pointsOdj.filter(
+          (pt) => pt.dossierLegislatifUid === dossier.uid && pt.etat !== "Annulé"
+        ).length > 0
+      ) {
+        seenAgendaUids.add(acte.agendaRef.uid);
+        reunions.push(acte.agendaRef);
+      }
+    }
+  });
+
+  return reunions;
 }

--- a/app/[legislature]/dossier/[id]/debat/DebateFilterBar.tsx
+++ b/app/[legislature]/dossier/[id]/debat/DebateFilterBar.tsx
@@ -15,24 +15,28 @@ import Typography from "@mui/material/Typography";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import Link from "next/link";
-import { ReturnedDebat } from "@/data/getDebats";
+
+import { Agenda } from "@prisma/client";
 
 type DebateFilterBarProps = {
-  debats: ReturnedDebat[];
+  reunions: Agenda[];
 };
 
 export const DebateFilterBar = (props: DebateFilterBarProps) => {
-  const { debats } = props;
-  const sceanceUid = useSelectedLayoutSegment();
+  // const { debats } = props;
+  const { reunions } = props;
+  const reunionUid = useSelectedLayoutSegment();
 
-  const debatIndex = debats.findIndex((debat) => debat.uid === sceanceUid);
-  if (!sceanceUid || debatIndex < 0) {
-    if (debats.length > 0) {
+  const debatIndex = reunions.findIndex((reu) => reu.uid === reunionUid);
+  
+  // const debatIndex = debats.findIndex((debat) => debat.uid === sceanceUid);
+  if (!reunionUid || debatIndex < 0) {
+    if (reunions.length > 0) {
       // Si le debat n'existe pas ou est vide, on redirige vers le premier débat disponible
-      if (sceanceUid) {
-        permanentRedirect(`${debats[0].uid}`);
+      if (reunionUid) {
+        permanentRedirect(`${reunions[0].uid}`);
       } else {
-        permanentRedirect(`debat/${debats[0].uid}`);
+        permanentRedirect(`debat/${reunions[0].uid}`);
       }
     }
   }
@@ -62,15 +66,26 @@ export const DebateFilterBar = (props: DebateFilterBarProps) => {
           justifyContent="space-between"
           sx={{ width: "100%" }}
         >
-          <Select value={sceanceUid} displayEmpty sx={{ flex: 1 }}>
-            {debats.map((debat) => {
+          <Select value={reunionUid} displayEmpty sx={{ flex: 1 }}>
+            {reunions.map((reunion) => {
+              const reunuionUid = reunion.uid;
+              // console.log(reunion.dateSeance)
+              console.log(reunion);
+                const dateSeanceJour = reunion.timestampDebut
+                ? new Date(reunion.timestampDebut).toLocaleDateString("fr-FR", {
+                  weekday: "long",
+                  day: "numeric",
+                  month: "long",
+                  year: "numeric",
+                  })
+                : "Date inconnue";
               return (
                 // @ts-ignore
                 <MenuItem
-                  key={debat.uid}
-                  value={debat.uid}
+                  key={reunuionUid}
+                  value={reunuionUid}
                   component={Link}
-                  href={debat.uid}
+                  href={reunuionUid}
                 >
                   <Typography
                     variant="caption"
@@ -81,7 +96,7 @@ export const DebateFilterBar = (props: DebateFilterBarProps) => {
                       },
                     }}
                   >
-                    {debat.dateSeanceJour}
+                    {dateSeanceJour}
                   </Typography>
                 </MenuItem>
               );
@@ -102,7 +117,7 @@ export const DebateFilterBar = (props: DebateFilterBarProps) => {
             <IconButton
               size="small"
               component={Link}
-              href={debatIndex <= 0 ? "" : debats[debatIndex - 1].uid!}
+              href={debatIndex <= 0 ? "" : reunions[debatIndex - 1].uid}
               disabled={debatIndex <= 0}
             >
               <ArrowBackIcon fontSize="small" />
@@ -111,11 +126,11 @@ export const DebateFilterBar = (props: DebateFilterBarProps) => {
               size="small"
               component={Link}
               href={
-                debatIndex >= debats.length - 1
+                debatIndex >= reunions.length - 1
                   ? ""
-                  : debats[debatIndex + 1].uid!
+                  : reunions[debatIndex + 1].uid
               }
-              disabled={debatIndex >= debats.length - 1}
+              disabled={debatIndex >= reunions.length - 1}
             >
               <ArrowForwardIcon fontSize="small" />
             </IconButton>

--- a/app/[legislature]/dossier/[id]/debat/[debatUid]/page.tsx
+++ b/app/[legislature]/dossier/[id]/debat/[debatUid]/page.tsx
@@ -3,19 +3,37 @@ import { DebateSummary } from "./DebateSummary";
 import { SUMMARY_CODES } from "@/components/const";
 import { DebateTranscript } from "./DebateTranscript";
 import { getInterventions } from "@/data/getInterventions";
-import { getDebats } from "@/data/getDebats";
+import { getDossier } from "@/data/getDossier";
 
 export default async function Page({
   params,
 }: {
   params: Promise<{ id: string; debatUid: string }>;
 }) {
-  const { id: dossierUid, debatUid } = await params;
 
-  const interventions = await getInterventions(debatUid);
-  const debats = await getDebats(dossierUid);
+  // url parameter is debatUid but it refers to agendaUid (reunion)
+  const { id: dossierUid, debatUid: agendaUid } = await params;
 
-  const debat = debats?.find((d) => d.uid === debatUid);
+  const dossier = await getDossier(dossierUid);
+  const acteSeance = dossier?.actesLegislatifs.find(
+    (acte) => acte.agendaRef?.uid === agendaUid
+  );
+  const agenda = acteSeance.agendaRef;
+  
+  // Identifier le point d'ordre associé à ce dossier législatif
+  const orderPoint = agenda.pointsOdj.find(
+    (pt) => (pt.dossierLegislatifUid === dossierUid && pt.etat === "Terminé"),
+  )?.valeurPtsOdj;
+  // on récupère les interventions associées à la reunion et à l'ordre du jour
+  const interventions = await getInterventions(agenda.compteRenduRefUid, orderPoint);
+  const dateSeanceJour = agenda.timestampDebut
+      ? new Date(agenda.timestampDebut).toLocaleDateString("fr-FR", {
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+        })
+      : "Date inconnue";
 
   if (!interventions || interventions.length === 0) {
     return <p>Aucun débat trouvé pour cette séance.</p>;
@@ -38,7 +56,7 @@ export default async function Page({
           [lastId]: acc[lastId] + texteLength,
         };
       } else {
-        console.log("codeGrammaire: ", codeGrammaire, paragraphe);
+        // console.log("codeGrammaire: ", codeGrammaire, paragraphe);
       }
       return acc;
     },
@@ -81,7 +99,7 @@ export default async function Page({
         }}
       >
         <DebateTranscript
-          title={debat?.dateSeanceJour ?? ""}
+          title={dateSeanceJour}
           paragraphes={interventions}
           wordsCounts={wordsCounts}
         />

--- a/app/[legislature]/dossier/[id]/debat/[debatUid]/page.tsx
+++ b/app/[legislature]/dossier/[id]/debat/[debatUid]/page.tsx
@@ -23,7 +23,8 @@ export default async function Page({
   // Identifier le point d'ordre associé à ce dossier législatif
   const orderPoint = agenda.pointsOdj.find(
     (pt) => (pt.dossierLegislatifUid === dossierUid && pt.etat === "Terminé"),
-  )?.valeurPtsOdj;
+  )?.ordrePoint;
+
   // on récupère les interventions associées à la reunion et à l'ordre du jour
   const interventions = await getInterventions(agenda.compteRenduRefUid, orderPoint);
   const dateSeanceJour = agenda.timestampDebut

--- a/app/[legislature]/dossier/[id]/debat/layout.tsx
+++ b/app/[legislature]/dossier/[id]/debat/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { DebateFilterBar } from "./DebateFilterBar";
 import { getDossier } from "@/data/getDossier";
+import { getReunionsWithCompteRendu } from "../dataFunctions";
 
 export default async function Layout({
   params,
@@ -16,28 +17,8 @@ export default async function Layout({
 
   const dossier = await getDossier(id);
 
-  // on recupère tous les object de reunion depuis les actes legisltaifs du dossier
-  // qui ont un compteRenduRefUid (donc un debat associé) et qui contiennent un point odj
-  // lié à ce dossier legislatif qui n'a pas été annulé
-  const reunionsWithCompteRendu: any[] = [];
-  const seenAgendaUids = new Set<string>();
-  
-  dossier?.actesLegislatifs.forEach((acte) => {
-    if (acte.agendaRef && acte.codeActe.includes("SEANCE")) {
-      // Skip si cette réunion a déjà été ajoutée
-      if (seenAgendaUids.has(acte.agendaRef.uid)) {
-        return;
-      }
+  const reunionsWithCompteRendu = getReunionsWithCompteRendu(dossier);
 
-      if (
-        acte.agendaRef.compteRenduRefUid &&
-        acte.agendaRef.pointsOdj.filter((pt) => (pt.dossierLegislatifUid === id && pt.etat != "Annulé")).length > 0  
-      ) {
-        seenAgendaUids.add(acte.agendaRef.uid);
-        reunionsWithCompteRendu.push(acte.agendaRef);
-      }
-    }
-  });
   if (reunionsWithCompteRendu.length === 0) {
     return <p>Aucun débat n&apos;a été trouvé pour ce dossier legislatif.</p>;
   }

--- a/app/[legislature]/dossier/[id]/debat/layout.tsx
+++ b/app/[legislature]/dossier/[id]/debat/layout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DebateFilterBar } from "./DebateFilterBar";
-import { getDebats } from "@/data/getDebats";
+import { getDossier } from "@/data/getDossier";
 
 export default async function Layout({
   params,
@@ -14,18 +14,37 @@ export default async function Layout({
 }) {
   const { id } = await params;
 
-  const debats = await getDebats(id);
+  const dossier = await getDossier(id);
 
-  const debatsDisponibles = debats?.filter(
-    (debat) => debat._count.paragraphes > 0
-  );
-  if (debatsDisponibles == null || debatsDisponibles.length === 0) {
+  // on recupère tous les object de reunion depuis les actes legisltaifs du dossier
+  // qui ont un compteRenduRefUid (donc un debat associé) et qui contiennent un point odj
+  // lié à ce dossier legislatif qui n'a pas été annulé
+  const reunionsWithCompteRendu: any[] = [];
+  const seenAgendaUids = new Set<string>();
+  
+  dossier?.actesLegislatifs.forEach((acte) => {
+    if (acte.agendaRef && acte.codeActe.includes("SEANCE")) {
+      // Skip si cette réunion a déjà été ajoutée
+      if (seenAgendaUids.has(acte.agendaRef.uid)) {
+        return;
+      }
+
+      if (
+        acte.agendaRef.compteRenduRefUid &&
+        acte.agendaRef.pointsOdj.filter((pt) => (pt.dossierLegislatifUid === id && pt.etat != "Annulé")).length > 0  
+      ) {
+        seenAgendaUids.add(acte.agendaRef.uid);
+        reunionsWithCompteRendu.push(acte.agendaRef);
+      }
+    }
+  });
+  if (reunionsWithCompteRendu.length === 0) {
     return <p>Aucun débat n&apos;a été trouvé pour ce dossier legislatif.</p>;
   }
 
   return (
     <>
-      <DebateFilterBar debats={debatsDisponibles} />
+      <DebateFilterBar reunions={reunionsWithCompteRendu} />
       <div className="container">{children}</div>
     </>
   );

--- a/app/[legislature]/dossier/[id]/layout.tsx
+++ b/app/[legislature]/dossier/[id]/layout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { HeroSection } from "@/components/folders/HeroSection";
 import Tabs from "./Tabs";
 
-import { getCurrentStatus } from "./dataFunctions";
+import { getCurrentStatus, getReunionsWithCompteRendu } from "./dataFunctions";
 import { getDossier } from "@/data/getDossier";
 import { dossierSettings } from "./dossierSettings";
 
@@ -28,6 +28,8 @@ export default async function Dossier({
     tableVotes = true,
   } = (codeProcedure ? dossierSettings[codeProcedure] : {}) ?? {};
   const status = getCurrentStatus(actesLegislatifs);
+  const reunionsDisponibles = getReunionsWithCompteRendu(dossier);
+  const hasDebats = reunionsDisponibles.length > 0;
 
   return (
     <React.Fragment>
@@ -43,6 +45,7 @@ export default async function Dossier({
         showDebats={tableDebats}
         showAmendements={tableAmendements}
         showVotes={tableVotes}
+        hasDebats={hasDebats}
       />
       {children}
     </React.Fragment>

--- a/components/folders/TimelineCard.tsx
+++ b/components/folders/TimelineCard.tsx
@@ -19,8 +19,6 @@ import { ActeLegislatif, Agenda } from "@prisma/client";
 import { groupActs } from "@/repository/Acts";
 import Image from "next/image";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
-import { getDebats } from "@/data/getDebats";
 
 // Utilitaire pour formater la date proprement
 const formatDate = (date?: Date | null) => {
@@ -234,18 +232,6 @@ export const TimelineCard = ({
   const [expandedLvl2, setExpandedLvl2] = React.useState<
     Record<string, boolean>
   >({});
-
-  const { data: debats } = useQuery({
-    queryKey: ["debats", dossierUid],
-    queryFn: async () => await getDebats(dossierUid),
-  });
-
-  const agendatsToDebatMap: Record<string, string> = {};
-  debats?.forEach((debat) => {
-    if (debat.reunionRefUid && debat._count.paragraphes > 0) {
-      agendatsToDebatMap[debat.reunionRefUid] = debat.uid;
-    }
-  });
 
   return (
     <CardLayout title="Chronologie du dossier">

--- a/components/folders/TimelineCard.tsx
+++ b/components/folders/TimelineCard.tsx
@@ -15,7 +15,7 @@ import Button from "@mui/material/Button";
 import { useTheme, useMediaQuery } from "@mui/material";
 
 import { CardLayout } from "@/components/folders/CardLayout";
-import { ActeLegislatif } from "@prisma/client";
+import { ActeLegislatif, Agenda } from "@prisma/client";
 import { groupActs } from "@/repository/Acts";
 import Image from "next/image";
 import Link from "next/link";
@@ -216,6 +216,31 @@ const TimelineItemLvl1 = ({
   );
 };
 
+const debatSeanceActeCodes = new Set([
+  "AN1-DEBATS-SEANCE",
+  "AN2-DEBATS-SEANCE",
+  "AN3-DEBATS-SEANCE",
+  "AN21-DEBATS-SEANCE",
+  "ANLDEF-DEBATS-SEANCE",
+  "ANLUNI-DEBATS-SEANCE",
+  "ANNLEC-DEBATS-SEANCE",
+]);
+
+const comReunionActeCodes = new Set([
+  "AN1-COM-FOND-REUNION",
+  "AN1-COM-AVIS-REUNION",
+  "AN2-COM-FOND-REUNION",
+  "AN2-COM-AVIS-REUNION",
+  "AN3-COM-FOND-REUNION",
+  "AN3-COM-AVIS-REUNION",
+  "ANLDEF-COM-FOND-REUNION",
+  "ANLUNI-COM-CAE-REUNION",
+  "ANLUNI-COM-FOND-REUNION",
+  "ANNLEC-COM-AVIS-REUNION",
+  "ANNLEC-COM-FOND-REUNION",
+]);
+
+
 export const TimelineCard = ({
   actesLegislatifs,
   dossierUid,
@@ -261,7 +286,11 @@ export const TimelineCard = ({
             : { flex: 0.2 },
         }}
       >
-        {rootIds?.map((rootId) => {
+        {(() => {
+          // Set pour tracker les agendaUids déjà affichés (éviter les duplicats)
+          const displayedAgendaUids = new Set<string>();
+          
+          return rootIds?.map((rootId) => {
           const act = actsLookup[rootId];
           return (
             <TimelineItemLvl0
@@ -288,13 +317,48 @@ export const TimelineCard = ({
                         ? allLvl3Uids
                         : allLvl3Uids.slice(0, 6);
 
-                      const debatUid =
-                        lvl2Act.reunionRefUid &&
-                        agendatsToDebatMap[lvl2Act.reunionRefUid];
-                      const link = debatUid
-                        ? `/${legislature}/dossier/${dossierUid}/debat/${debatUid}`
-                        : undefined;
 
+                      
+                      //
+                      let link;
+                      
+                      if (debatSeanceActeCodes.has(lvl2Act.codeActe)) {
+                        //
+                        const agenda: Agenda = lvl2Act.agendaRef;
+                        
+                        // Skip si cet agenda a déjà été affiché
+                        if (agenda?.uid && displayedAgendaUids.has(agenda.uid)) {
+                          return null;
+                        }
+                        // on récupère les point odj associés à ce dossier législatif
+                        const matchingPoints = agenda?.pointsOdj?.filter(
+                          (point) => 
+                            point.dossierLegislatifUid === lvl2Act.dossierRefUid
+                        ) || [];
+                        
+                        if (matchingPoints.length === 0) {
+                          console.log("Aucun point d'ordre du jour trouvé pour l'acte: ", lvl2Act.uid);
+                          return null; // Skip cet élément
+                        }
+
+                        const hasTerminePoint = matchingPoints.some(
+                          (point) => point.etat === "Terminé"
+                        );
+
+                        if (!hasTerminePoint) {
+                          console.warn("Aucun point terminé trouvé pour l'acte: ", lvl2Act.uid);
+                          return null; // Skip cet élément
+                        }
+                        
+                        // Pour eviter les "dupliquats" d'acte qui pointent vers la meme reunion"
+                        if (agenda?.uid) {
+                          displayedAgendaUids.add(agenda.uid);
+                        }
+                        
+                        // on utilise l'id de la reunion pour gérer la page debat (plus facile)
+                        link = `/${legislature}/dossier/${dossierUid}/debat/${agenda.uid}`;
+                      }
+                      
                       const dateLvl2 = formatDate(lvl2Act.date);
                       const lvl2Title = `${lvl2Act.nomCanonique} ${
                         lvl2Act.date ? `(${dateLvl2})` : ""
@@ -325,11 +389,33 @@ export const TimelineCard = ({
                           {displayedLvl3Uids.map((lvl3Uid) => {
                             const lvl3Act = actsLookup[lvl3Uid];
                             const date3Str = formatDate(lvl3Act.dateActe);
+
+                            // link to CR de reunion de commission
+                            // let link = undefined;
+                            // if (comReunionActeCodes.has(lvl3Act.codeActe)) {
+                            //   // Si acte de réunion de commission
+                            //   // on filtre les point ordre du jour qui sont terminé
+                            //   const finishedPodj = lvl3Act.agendaRef?.pointsOdj?.filter(
+                            //     point => point.etat === "Terminé"
+                            //   ) || [];
+                            //   // on check le nombre de sujet à l'ordre du jour:
+                            //   // const nOjd = finishedPodj.length;
+                            //   // console.log("nOjd:", nOjd);
+                            //   // Si on a un seul point à l'ordre du jour, on peut linker directement vers le débat
+                            //   const debatUid = lvl3Act.agendaRef?.transcriptionRefUid || lvl3Act.agendaRef?.compteRenduRefUid;
+                            //   link =
+                            //     debatUid && (finishedPodj.length === 1)
+                            //       ? `/${legislature}/dossier/${dossierUid}/debat/${debatUid}`
+                            //       : undefined;
+                            // }
+
                             return (
                               <Typography
                                 key={lvl3Uid}
                                 variant="caption"
                                 component="p"
+                                // component={link ? Link : "p"}
+                                // href={link}
                                 sx={{
                                   ml: 2,
                                   color: "grey.600",
@@ -373,7 +459,8 @@ export const TimelineCard = ({
               })}
             </TimelineItemLvl0>
           );
-        })}
+        });
+        })()}
       </Timeline>
     </CardLayout>
   );

--- a/components/folders/TimelineCard.tsx
+++ b/components/folders/TimelineCard.tsx
@@ -216,30 +216,6 @@ const TimelineItemLvl1 = ({
   );
 };
 
-const debatSeanceActeCodes = new Set([
-  "AN1-DEBATS-SEANCE",
-  "AN2-DEBATS-SEANCE",
-  "AN3-DEBATS-SEANCE",
-  "AN21-DEBATS-SEANCE",
-  "ANLDEF-DEBATS-SEANCE",
-  "ANLUNI-DEBATS-SEANCE",
-  "ANNLEC-DEBATS-SEANCE",
-]);
-
-const comReunionActeCodes = new Set([
-  "AN1-COM-FOND-REUNION",
-  "AN1-COM-AVIS-REUNION",
-  "AN2-COM-FOND-REUNION",
-  "AN2-COM-AVIS-REUNION",
-  "AN3-COM-FOND-REUNION",
-  "AN3-COM-AVIS-REUNION",
-  "ANLDEF-COM-FOND-REUNION",
-  "ANLUNI-COM-CAE-REUNION",
-  "ANLUNI-COM-FOND-REUNION",
-  "ANNLEC-COM-AVIS-REUNION",
-  "ANNLEC-COM-FOND-REUNION",
-]);
-
 
 export const TimelineCard = ({
   actesLegislatifs,
@@ -322,7 +298,7 @@ export const TimelineCard = ({
                       //
                       let link;
                       
-                      if (debatSeanceActeCodes.has(lvl2Act.codeActe)) {
+                      if (lvl2Act.codeActe.includes("SEANCE")) {
                         //
                         const agenda: Agenda = lvl2Act.agendaRef;
                         
@@ -351,10 +327,8 @@ export const TimelineCard = ({
                         }
                         
                         // Pour eviter les "dupliquats" d'acte qui pointent vers la meme reunion"
-                        if (agenda?.uid) {
-                          displayedAgendaUids.add(agenda.uid);
-                        }
-                        
+                        displayedAgendaUids.add(agenda.uid);
+
                         // on utilise l'id de la reunion pour gérer la page debat (plus facile)
                         link = `/${legislature}/dossier/${dossierUid}/debat/${agenda.uid}`;
                       }

--- a/data/getDebats.ts
+++ b/data/getDebats.ts
@@ -16,6 +16,8 @@ async function getDebatsUnCached(
       .filter((deb) => deb.chambre === 'AN')
       .map((deb) => deb.uid);
 
+    // console.log(debatsUids);
+
     if (debatsUids.length === 0) {
       return [];
     }

--- a/data/getDossier.ts
+++ b/data/getDossier.ts
@@ -16,7 +16,7 @@ async function getDossierUnCached(uid: string): Promise<
 > {
   try {
     const rep = await fetch(
-      `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/dossiers/${uid}?include=actesLegislatifs,rapporteurs`
+      `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/dossiers/${uid}?include=actesLegislatifs.agendaRef.pointsOdj,rapporteurs`
     );
 
     const { data } = await rep.json();

--- a/data/getInterventions.ts
+++ b/data/getInterventions.ts
@@ -11,7 +11,7 @@ async function getInterventionsUnCached(debatUid: string, ordrePoint?: string): 
         if (ordrePoint) {
             params.set('valeurPtsOdj', ordrePoint);
         }
-        console.log(`${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/interventions/?${params.toString()}`)
+        // console.log(`${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/interventions/?${params.toString()}`)
         const rep = await fetch(
             `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/interventions/?${params.toString()}`
         );

--- a/data/getInterventions.ts
+++ b/data/getInterventions.ts
@@ -1,10 +1,19 @@
 import * as React from 'react'
 import { Paragraphe } from "@prisma/client";
 
-async function getInterventionsUnCached(debatUid: string): Promise<Paragraphe[]> {
+async function getInterventionsUnCached(debatUid: string, ordrePoint?: string): Promise<Paragraphe[]> {
     try {
+        const params = new URLSearchParams({
+            debatRefUid: debatUid,
+            perPage: '1000',
+            sort: 'ordreAbsoluSeance.asc',
+        });
+        if (ordrePoint) {
+            params.set('valeurPtsOdj', ordrePoint);
+        }
+        console.log(`${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/interventions/?${params.toString()}`)
         const rep = await fetch(
-            `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/interventions/?debatRefUid=${debatUid}&perPage=1000`
+            `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/interventions/?${params.toString()}`
         );
 
         const { data } = await rep.json();
@@ -16,7 +25,7 @@ async function getInterventionsUnCached(debatUid: string): Promise<Paragraphe[]>
 
         return data;
     } catch (error) {
-        console.error("Error fetching dossier:", error);
+        console.error("Error fetching interventions:", error);
         return [];
     }
 }


### PR DESCRIPTION

- Utilise les agenda/reunion pour les URL et les data sur les debats plutot que les objects de CR
    - Les réunions/agendas sont plus pratiques que les comptes rendus car on a l'ordre du jour (pointsOdj), etc.
    - On récupère ensuite les interventions via l'API comme avant, en filtrant par ordrePoint
- Déduplique les actes pointant vers la même réunion dans la timeline et le sélecteur
- Simplifie Tabs.tsx en calculant hasDebats
- Ajout de relation sur le getDossier: `agendaRef.pointsOdj`
- Pour l'instant uniquement pour les debats en séance et pas les reu de commission. Pour les reu de commission on a pas les ordres du jour pour filtrer les bon morceaux du CR :/