### PR TITLE
Fix/Improve autocomplete de la homepage

### DIFF
--- a/components/home/SearchBar.tsx
+++ b/components/home/SearchBar.tsx
@@ -5,7 +5,6 @@ import {
   TextField,
   Typography,
   Box,
-  CircularProgress,
   Stack,
   Avatar,
 } from "@mui/material";
@@ -13,34 +12,33 @@ import debounce from "@/utils/debounce";
 import { Dossier, Acteur } from "@prisma/client";
 import { searchDossier } from "@/data/searchDossier";
 import { searchActeur } from "@/data/searchActeur";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useTransition } from "react";
-import {
-  type CirconscriptionLegislative Suggestion,
-  deputeAutocompletions,
-} from "@/data/autocomplet/suggestions";
-import { useQuery } from "@tanstack/react-query";
-import { getActeur } from "@/data/getActeur";
+import { TYPES_DE_DOSSIERS } from "@/components/const";
 
-type Require<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-type Circonscription = Require<CirconscriptionLegislativeSuggestion, "depute">;
+// ─── Circo search (code4code.eu) — désactivé pour l'instant, à réactiver si besoin ───
+// import {
+//   type CirconscriptionLegislativeSuggestion,
+//   deputeAutocompletions,
+// } from "@/data/autocomplet/suggestions";
+// import { useQuery } from "@tanstack/react-query";
+// import { getActeur } from "@/data/getActeur";
+//
+// type Require<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+// type Circonscription = Require<CirconscriptionLegislativeSuggestion, "depute">;
+//
+// const ENABLE_CIRCO_SEARCH = false;
+//
+// const fetchActeurs = debounce(
+//   (search: string, callback: (results: readonly CirconscriptionLegislativeSuggestion[]) => void) =>
+//     deputeAutocompletions(search).then(callback)
+// );
+// ─────────────────────────────────────────────────────────────────────────────
 
-// Call 1: code4code.eu (location-based)
-const fetchActeurs = debounce(
-  (
-    search: string,
-    callback: (results: readonly CirconscriptionLegislativeSuggestion[]) => void
-  ) => deputeAutocompletions(search).then(callback)
-);
-
-// Call 2: internal API (name-based, with prefixSearch)
 const fetchActeursByName = debounce(
   (search: string, callback: (results: Acteur[]) => void) =>
     searchActeur(search).then(callback)
 );
 
-// Call 3: dossiers (with prefixSearch)
 const fetchDossiers = debounce(
   (search: string, callback: (results: null | readonly Dossier[]) => void) =>
     searchDossier({ search }).then((result) => callback(result?.data ?? null))
@@ -48,67 +46,38 @@ const fetchDossiers = debounce(
 
 const emptyOptions = [] as const;
 
-type SearchOption = Circonscription | Acteur | Dossier;
+type SearchOption = Acteur | Dossier;
 
-function isCirconscriptionActeur(item: SearchOption): item is Circonscription {
-  return "depute" in item && (item as CirconscriptionLegislativeSuggestion).depute !== undefined;
-}
-
-function isPrismaActeur(item: SearchOption): item is Acteur {
-  return "prenom" in item && !("depute" in item) && !("titre" in item);
+function isActeur(item: SearchOption): item is Acteur {
+  return "prenom" in item;
 }
 
 export default function SearchBar() {
   const router = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const [value, setValue] = React.useState<SearchOption | null>(null);
   const [inputValue, setInputValue] = React.useState("");
-  const [deputesOptions, setDeputesOptions] =
-    React.useState<readonly Circonscription[]>(emptyOptions);
-  const [nameActeurOptions, setNameActeurOptions] =
+  const [isSearching, setIsSearching] = React.useState(false);
+  const [acteurOptions, setActeurOptions] =
     React.useState<readonly Acteur[]>(emptyOptions);
   const [dossierOptions, setDossierOptions] =
     React.useState<readonly Dossier[]>(emptyOptions);
 
   React.useEffect(() => {
     if (inputValue === "") {
-      if (value && isCirconscriptionActeur(value)) {
-        setDeputesOptions([value]);
-      } else {
-        setDeputesOptions(emptyOptions);
-      }
-      setNameActeurOptions(emptyOptions);
-      if (value && !isCirconscriptionActeur(value) && !isPrismaActeur(value)) {
-        setDossierOptions([value as Dossier]);
-      } else {
-        setDossierOptions(emptyOptions);
-      }
+      setIsSearching(false);
+      setActeurOptions(emptyOptions);
+      setDossierOptions(emptyOptions);
       return undefined;
     }
 
     let active = true;
+    setIsSearching(true);
 
-    // Call 1 — code4code.eu (location-based)
-    fetchActeurs(
-      inputValue,
-      (results: readonly CirconscriptionLegislativeSuggestion[]) => {
-        if (!active) return;
-        setDeputesOptions(
-          results.filter(
-            (suggestion): suggestion is Circonscription =>
-              suggestion.depute !== undefined && suggestion.score > 0.5
-          )
-        );
-      }
-    );
-
-    // Call 2 — internal API (name-based)
     fetchActeursByName(inputValue, (results: Acteur[]) => {
       if (!active) return;
-      setNameActeurOptions(results);
+      setActeurOptions(results);
+      setIsSearching(false);
     });
 
-    // Call 3 — dossiers
     fetchDossiers(inputValue, (results: null | readonly Dossier[]) => {
       if (!active) return;
       setDossierOptions(results ?? emptyOptions);
@@ -117,22 +86,11 @@ export default function SearchBar() {
     return () => {
       active = false;
     };
-  }, [value, inputValue]);
-
-  // Merge location-based and name-based deputies, deduplicating by uid
-  const mergedActeurs = React.useMemo(() => {
-    const locationUids = new Set(deputesOptions.map((s) => s.depute.uid));
-    const nameOnly = nameActeurOptions.filter((a) => !locationUids.has(a.uid));
-    const maxLocation = Math.min(3, deputesOptions.length);
-    return [
-      ...deputesOptions.slice(0, maxLocation),
-      ...nameOnly.slice(0, 5 - maxLocation),
-    ];
-  }, [deputesOptions, nameActeurOptions]);
+  }, [inputValue]);
 
   const options: SearchOption[] = React.useMemo(
-    () => [...mergedActeurs, ...dossierOptions.slice(0, 5)],
-    [mergedActeurs, dossierOptions]
+    () => [...acteurOptions.slice(0, 5), ...dossierOptions.slice(0, 5)],
+    [acteurOptions, dossierOptions]
   );
 
   return (
@@ -140,12 +98,7 @@ export default function SearchBar() {
       <Autocomplete
         getOptionLabel={(option) => {
           if (typeof option === "string") return option;
-          if (isCirconscriptionActeur(option)) {
-            return `${option.depute.etatCivil.ident.prenom} ${option.depute.etatCivil.ident.nom}`;
-          }
-          if (isPrismaActeur(option)) {
-            return `${option.prenom} ${option.nom}`;
-          }
+          if (isActeur(option)) return `${option.prenom} ${option.nom}`;
           return (option as Dossier).titre ?? "";
         }}
         slotProps={{
@@ -164,32 +117,24 @@ export default function SearchBar() {
         includeInputInList
         filterSelectedOptions
         popupIcon={null}
-        value={value}
         inputValue={inputValue}
-        noOptionsText={isPending ? "Recherche en cours..." : "Aucun résultat"}
+        value={null}
+        noOptionsText={isSearching ? "" : "Aucun résultat"}
         openOnFocus={false}
         open={inputValue.length > 2}
         groupBy={(option) =>
-          "titre" in option ? "Dossiers législatifs" : "Député·e·s"
+          isActeur(option) ? "Député·e·s" : "Dossiers législatifs"
         }
         renderGroup={(params) => (
           <li key={params.key}>
-            <Box
-              sx={{
-                px: 2,
-                py: 0.75,
-                borderBottom: "1px solid",
-                borderColor: "divider",
-              }}
-            >
+            <Box sx={{ px: 2.5, pt: 1.5, pb: 0.75 }}>
               <Typography
-                variant="caption"
                 sx={{
-                  fontWeight: 700,
+                  fontWeight: 800,
+                  fontSize: "0.7rem",
+                  letterSpacing: "0.07em",
+                  color: "text.primary",
                   textTransform: "uppercase",
-                  fontSize: "0.65rem",
-                  letterSpacing: "0.08em",
-                  color: "text.secondary",
                 }}
               >
                 {params.group}
@@ -198,8 +143,21 @@ export default function SearchBar() {
             <ul style={{ padding: 0 }}>{params.children}</ul>
           </li>
         )}
-        onInputChange={(event, newInputValue) => {
-          setInputValue(newInputValue);
+        onInputChange={(event, newInputValue, reason) => {
+          // Ignorer 'reset' (sélection d'une option) pour éviter de relancer le search
+          if (reason === "input") setInputValue(newInputValue);
+          if (reason === "clear") setInputValue("");
+        }}
+        onChange={(event, selectedOption) => {
+          if (!selectedOption || typeof selectedOption === "string") return;
+          setInputValue("");
+          if (isActeur(selectedOption)) {
+            const slug = selectedOption.slug;
+            if (slug) router.push(`/depute/${slug}`);
+          } else {
+            const d = selectedOption as Dossier;
+            router.push(`/${d.legislature ?? 17}/dossier/${d.uid}`);
+          }
         }}
         renderInput={(params) => (
           <TextField
@@ -218,121 +176,147 @@ export default function SearchBar() {
               },
             }}
             fullWidth
-            placeholder="Entrez un code postal, un nom de député ou un nom de dossier législatif"
-            inputProps={{
-              ...params.inputProps,
-            }}
+            placeholder="Entrez un nom de député ou un nom de dossier législatif"
+            inputProps={{ ...params.inputProps }}
             InputProps={{
               ...params.InputProps,
-              endAdornment: isPending ? (
-                <CircularProgress size={20} />
-              ) : (
-                params.InputProps.endAdornment
-              ),
             }}
           />
         )}
         renderOption={({ key, ...props }, option) => {
-          if (isCirconscriptionActeur(option)) {
+          if (isActeur(option)) {
             return (
-              <li key={key} {...props} style={{ padding: "12px 10px" }}>
-                <ActeurOption {...option} />
-              </li>
-            );
-          }
-          if (isPrismaActeur(option)) {
-            return (
-              <li key={key} {...props} style={{ padding: "12px 10px" }}>
-                <PrismaActeurOption acteur={option} />
+              <li key={key} {...props} style={{ padding: "8px 16px" }}>
+                <ActeurOption acteur={option} />
               </li>
             );
           }
           return (
-            <li key={key} {...props} style={{ padding: "12px 10px" }}>
-              <Link
-                href={`/17/dossier/${(option as Dossier).uid}`}
-                style={{ width: "100%" }}
-              >
-                {(option as Dossier).titre}
-              </Link>
+            <li key={key} {...props} style={{ padding: "8px 16px" }}>
+              <DossierOption dossier={option as Dossier} />
             </li>
           );
         }}
       />
       <Typography variant="caption" sx={{ mt: 2 }} fontWeight="light">
-        Ex. Yaël Braun-Pivet, Loi Finance, 59650, Lyon, ...
+        Ex. Yaël Braun-Pivet, Loi Finance, ...
       </Typography>
     </Box>
   );
 }
 
-// For location-based results (code4code.eu) — still needs useQuery for slug/urlImage
-export function ActeurOption(props: Circonscription) {
-  const { data: acteur } = useQuery({
-    queryKey: ["acteur", props.depute.uid],
-    queryFn: async () =>
-      props.depute.uid == null ? null : await getActeur(props.depute.uid),
-    enabled: !!props.depute.uid,
-  });
-
-  const { nom, prenom } = props.depute.etatCivil.ident;
-
-  if (!acteur) {
-    return null;
-  }
+function ActeurOption({ acteur }: { acteur: Acteur }) {
   return (
-    <Link href={`/depute/${acteur.slug}`}>
-      <Stack direction="row" spacing={1.5}>
-        <Avatar
-          sx={{ height: 46, width: 46 }}
-          alt={"photo de " + prenom + " " + nom}
-          src={acteur?.urlImage ?? ""}
-        >
-          {prenom[0].toUpperCase()}
-          {nom[0].toUpperCase()}
-        </Avatar>
-        <div style={{ flexGrow: 1 }}>
-          <Typography variant="body1" fontWeight="bold">
-            {prenom} {nom}
+    <Stack direction="row" spacing={1.5} alignItems="center" sx={{ width: "100%" }}>
+      <Avatar
+        sx={{ height: 46, width: 46, flexShrink: 0 }}
+        alt={`photo de ${acteur.prenom} ${acteur.nom}`}
+        src={acteur.urlImage ?? ""}
+      >
+        {acteur.prenom?.[0]?.toUpperCase()}
+        {acteur.nom?.[0]?.toUpperCase()}
+      </Avatar>
+      <Box>
+        <Typography variant="body2" fontWeight={700} lineHeight={1.3}>
+          {acteur.prenom} {acteur.nom}
+        </Typography>
+        {acteur.groupeParlementaire?.libelleTronque && (
+          <Typography variant="caption" color="text.secondary" lineHeight={1.3}>
+            {acteur.groupeParlementaire.libelleTronque}
           </Typography>
-          <Stack direction="row" spacing={1} justifyContent="space-between">
-            {props.circonscription_legislative && (
-              <Typography variant="body1" fontWeight="light">
-                {props.circonscription_legislative.libelle}
-              </Typography>
-            )}
-            {props.role !== "député" && (
-              <Typography variant="body1" fontWeight="light" textAlign="end">
-                {props.autocompletion}
-              </Typography>
-            )}
-          </Stack>
-        </div>
-      </Stack>
-    </Link>
+        )}
+      </Box>
+    </Stack>
   );
 }
 
-// For name-based results (internal API) — data already available, no extra query needed
-function PrismaActeurOption({ acteur }: { acteur: Acteur }) {
-  if (!acteur.slug) return null;
+const DOSSIER_ABBREV: Record<string, string> = {
+  "1": "PL",
+  "2": "PP",
+  "3": "LF",
+  "4": "SS",
+  "5": "LO",
+  "6": "RT",
+  "7": "LC",
+  "8": "RS",
+  "9": "CE",
+  "10": "MI",
+  "13": "49",
+  "16": "PT",
+  "17": "MR",
+  "19": "RI",
+};
+
+function DossierOption({ dossier }: { dossier: Dossier }) {
+  const typeInfo = TYPES_DE_DOSSIERS.find(
+    (t) => t.code === dossier.codeProcedure
+  );
+  const typeLabel = typeInfo?.label ?? "Dossier législatif";
+  const abbrev = (dossier.codeProcedure && DOSSIER_ABBREV[dossier.codeProcedure]) ?? "DL";
+
   return (
-    <Link href={`/depute/${acteur.slug}`}>
-      <Stack direction="row" spacing={1.5}>
-        <Avatar
-          sx={{ height: 46, width: 46 }}
-          alt={"photo de " + acteur.prenom + " " + acteur.nom}
-          src={acteur.urlImage ?? ""}
+    <Stack direction="row" spacing={1.5} alignItems="center" sx={{ width: "100%" }}>
+      <Avatar
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          bgcolor: "transparent",
+          border: "1.5px solid",
+          borderColor: "grey.400",
+          color: "grey.600",
+          fontSize: "0.8rem",
+          fontWeight: 700,
+          letterSpacing: "0.05em",
+        }}
+      >
+        {abbrev}
+      </Avatar>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography
+          variant="body2"
+          fontWeight={700}
+          lineHeight={1.3}
+          sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
         >
-          {acteur.prenom?.[0]?.toUpperCase()}
-          {acteur.nom?.[0]?.toUpperCase()}
-        </Avatar>
-        <div style={{ flexGrow: 1 }}>
-          <Typography variant="body1" fontWeight="bold">
-            {acteur.prenom} {acteur.nom}
-          </Typography>
-        </div>
-      </Stack>
-    </Link>
+          {dossier.titre}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" lineHeight={1.3}>
+          {typeLabel}
+        </Typography>
+      </Box>
+    </Stack>
   );
 }
+
+// ─── Circo search — kept for future reactivation ────────────────────────────
+// export function ActeurOptionFromCirco(props: Circonscription) {
+//   const { data: acteur } = useQuery({
+//     queryKey: ["acteur", props.depute.uid],
+//     queryFn: async () =>
+//       props.depute.uid == null ? null : await getActeur(props.depute.uid),
+//     enabled: !!props.depute.uid,
+//   });
+//
+//   const { nom, prenom } = props.depute.etatCivil.ident;
+//   if (!acteur) return null;
+//
+//   return (
+//     <Link href={`/depute/${acteur.slug}`} style={{ width: "100%" }}>
+//       <Stack direction="row" spacing={1.5} alignItems="center">
+//         <Avatar sx={{ height: 46, width: 46 }} src={acteur.urlImage ?? ""}>
+//           {prenom[0].toUpperCase()}{nom[0].toUpperCase()}
+//         </Avatar>
+//         <Box>
+//           <Typography variant="body2" fontWeight={700}>{prenom} {nom}</Typography>
+//           {props.circonscription_legislative && (
+//             <Typography variant="caption" color="text.secondary">
+//               {props.circonscription_legislative.libelle}
+//             </Typography>
+//           )}
+//         </Box>
+//       </Stack>
+//     </Link>
+//   );
+// }
+// ─────────────────────────────────────────────────────────────────────────────

--- a/components/home/SearchBar.tsx
+++ b/components/home/SearchBar.tsx
@@ -9,9 +9,9 @@ import {
   Avatar,
 } from "@mui/material";
 import debounce from "@/utils/debounce";
-import { Dossier, Acteur } from "@prisma/client";
+import { Dossier } from "@prisma/client";
 import { searchDossier } from "@/data/searchDossier";
-import { searchActeur } from "@/data/searchActeur";
+import { searchActeur, ActeurWithGroupe } from "@/data/searchActeur";
 import { useRouter } from "next/navigation";
 import { TYPES_DE_DOSSIERS } from "@/components/const";
 
@@ -35,7 +35,7 @@ import { TYPES_DE_DOSSIERS } from "@/components/const";
 // ─────────────────────────────────────────────────────────────────────────────
 
 const fetchActeursByName = debounce(
-  (search: string, callback: (results: Acteur[]) => void) =>
+  (search: string, callback: (results: ActeurWithGroupe[]) => void) =>
     searchActeur(search).then(callback)
 );
 
@@ -46,9 +46,9 @@ const fetchDossiers = debounce(
 
 const emptyOptions = [] as const;
 
-type SearchOption = Acteur | Dossier;
+type SearchOption = ActeurWithGroupe | Dossier;
 
-function isActeur(item: SearchOption): item is Acteur {
+function isActeur(item: SearchOption): item is ActeurWithGroupe {
   return "prenom" in item;
 }
 
@@ -57,7 +57,7 @@ export default function SearchBar() {
   const [inputValue, setInputValue] = React.useState("");
   const [isSearching, setIsSearching] = React.useState(false);
   const [acteurOptions, setActeurOptions] =
-    React.useState<readonly Acteur[]>(emptyOptions);
+    React.useState<readonly ActeurWithGroupe[]>(emptyOptions);
   const [dossierOptions, setDossierOptions] =
     React.useState<readonly Dossier[]>(emptyOptions);
 
@@ -72,7 +72,7 @@ export default function SearchBar() {
     let active = true;
     setIsSearching(true);
 
-    fetchActeursByName(inputValue, (results: Acteur[]) => {
+    fetchActeursByName(inputValue, (results: ActeurWithGroupe[]) => {
       if (!active) return;
       setActeurOptions(results);
       setIsSearching(false);
@@ -205,7 +205,7 @@ export default function SearchBar() {
   );
 }
 
-function ActeurOption({ acteur }: { acteur: Acteur }) {
+function ActeurOption({ acteur }: { acteur: ActeurWithGroupe }) {
   return (
     <Stack direction="row" spacing={1.5} alignItems="center" sx={{ width: "100%" }}>
       <Avatar

--- a/components/home/SearchBar.tsx
+++ b/components/home/SearchBar.tsx
@@ -1,6 +1,5 @@
 "use client";
 import * as React from "react";
-import Image from "next/image";
 import {
   Autocomplete,
   TextField,
@@ -11,18 +10,23 @@ import {
   Avatar,
 } from "@mui/material";
 import debounce from "@/utils/debounce";
-import { Dossier } from "@prisma/client";
+import { Dossier, Acteur } from "@prisma/client";
 import { searchDossier } from "@/data/searchDossier";
+import { searchActeur } from "@/data/searchActeur";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
 import {
-  type CirconscriptionLegislativeSuggestion,
+  type CirconscriptionLegislative Suggestion,
   deputeAutocompletions,
 } from "@/data/autocomplet/suggestions";
 import { useQuery } from "@tanstack/react-query";
 import { getActeur } from "@/data/getActeur";
 
+type Require<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+type Circonscription = Require<CirconscriptionLegislativeSuggestion, "depute">;
+
+// Call 1: code4code.eu (location-based)
 const fetchActeurs = debounce(
   (
     search: string,
@@ -30,50 +34,65 @@ const fetchActeurs = debounce(
   ) => deputeAutocompletions(search).then(callback)
 );
 
+// Call 2: internal API (name-based, with prefixSearch)
+const fetchActeursByName = debounce(
+  (search: string, callback: (results: Acteur[]) => void) =>
+    searchActeur(search).then(callback)
+);
+
+// Call 3: dossiers (with prefixSearch)
 const fetchDossiers = debounce(
   (search: string, callback: (results: null | readonly Dossier[]) => void) =>
     searchDossier({ search }).then((result) => callback(result?.data ?? null))
 );
+
 const emptyOptions = [] as const;
 
-function isActeur(
-  item: Dossier | CirconscriptionLegislativeSuggestion
-): item is CirconscriptionLegislativeSuggestion {
-  return (item as CirconscriptionLegislativeSuggestion).depute !== undefined;
+type SearchOption = Circonscription | Acteur | Dossier;
+
+function isCirconscriptionActeur(item: SearchOption): item is Circonscription {
+  return "depute" in item && (item as CirconscriptionLegislativeSuggestion).depute !== undefined;
 }
 
-type Require<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+function isPrismaActeur(item: SearchOption): item is Acteur {
+  return "prenom" in item && !("depute" in item) && !("titre" in item);
+}
 
-type Circonscription = Require<CirconscriptionLegislativeSuggestion, "depute">;
 export default function SearchBar() {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
-  const [value, setValue] = React.useState<Circonscription | Dossier | null>(
-    null
-  );
+  const [value, setValue] = React.useState<SearchOption | null>(null);
   const [inputValue, setInputValue] = React.useState("");
   const [deputesOptions, setDeputesOptions] =
     React.useState<readonly Circonscription[]>(emptyOptions);
+  const [nameActeurOptions, setNameActeurOptions] =
+    React.useState<readonly Acteur[]>(emptyOptions);
   const [dossierOptions, setDossierOptions] =
     React.useState<readonly Dossier[]>(emptyOptions);
 
   React.useEffect(() => {
     if (inputValue === "") {
-      setDeputesOptions(value && isActeur(value) ? [value] : emptyOptions);
-      setDossierOptions(value && !isActeur(value) ? [value] : emptyOptions);
+      if (value && isCirconscriptionActeur(value)) {
+        setDeputesOptions([value]);
+      } else {
+        setDeputesOptions(emptyOptions);
+      }
+      setNameActeurOptions(emptyOptions);
+      if (value && !isCirconscriptionActeur(value) && !isPrismaActeur(value)) {
+        setDossierOptions([value as Dossier]);
+      } else {
+        setDossierOptions(emptyOptions);
+      }
       return undefined;
     }
 
-    // Allow to resolve the out of order request resolution.
     let active = true;
 
+    // Call 1 — code4code.eu (location-based)
     fetchActeurs(
       inputValue,
       (results: readonly CirconscriptionLegislativeSuggestion[]) => {
-        if (!active) {
-          return;
-        }
-
+        if (!active) return;
         setDeputesOptions(
           results.filter(
             (suggestion): suggestion is Circonscription =>
@@ -82,16 +101,17 @@ export default function SearchBar() {
         );
       }
     );
-    fetchDossiers(inputValue, (results: null | readonly Dossier[]) => {
-      if (!active) {
-        return;
-      }
 
-      if (results === null) {
-        setDossierOptions(emptyOptions);
-        return;
-      }
-      setDossierOptions(results);
+    // Call 2 — internal API (name-based)
+    fetchActeursByName(inputValue, (results: Acteur[]) => {
+      if (!active) return;
+      setNameActeurOptions(results);
+    });
+
+    // Call 3 — dossiers
+    fetchDossiers(inputValue, (results: null | readonly Dossier[]) => {
+      if (!active) return;
+      setDossierOptions(results ?? emptyOptions);
     });
 
     return () => {
@@ -99,33 +119,45 @@ export default function SearchBar() {
     };
   }, [value, inputValue]);
 
-  const options: (Circonscription | Dossier)[] = React.useMemo(
-    () => [...deputesOptions.slice(0, 5), ...dossierOptions.slice(0, 5)],
-    [deputesOptions, dossierOptions]
+  // Merge location-based and name-based deputies, deduplicating by uid
+  const mergedActeurs = React.useMemo(() => {
+    const locationUids = new Set(deputesOptions.map((s) => s.depute.uid));
+    const nameOnly = nameActeurOptions.filter((a) => !locationUids.has(a.uid));
+    const maxLocation = Math.min(3, deputesOptions.length);
+    return [
+      ...deputesOptions.slice(0, maxLocation),
+      ...nameOnly.slice(0, 5 - maxLocation),
+    ];
+  }, [deputesOptions, nameActeurOptions]);
+
+  const options: SearchOption[] = React.useMemo(
+    () => [...mergedActeurs, ...dossierOptions.slice(0, 5)],
+    [mergedActeurs, dossierOptions]
   );
 
   return (
     <Box sx={{ maxWidth: 709, width: "100%" }}>
       <Autocomplete
         getOptionLabel={(option) => {
-          if (typeof option === "string") {
-            return option;
-          }
-          if (isActeur(option)) {
+          if (typeof option === "string") return option;
+          if (isCirconscriptionActeur(option)) {
             return `${option.depute.etatCivil.ident.prenom} ${option.depute.etatCivil.ident.nom}`;
           }
-          return option.titre!;
+          if (isPrismaActeur(option)) {
+            return `${option.prenom} ${option.nom}`;
+          }
+          return (option as Dossier).titre ?? "";
         }}
         slotProps={{
-            paper: {
-              sx: {
-                marginTop: "8px",
-                borderRadius: "20px",
-                boxShadow: "0px 4px 20px rgba(0,0,0,0.08)",
-                "&:empty": { display: "none" }
-              },
+          paper: {
+            sx: {
+              marginTop: "8px",
+              borderRadius: "20px",
+              boxShadow: "0px 4px 20px rgba(0,0,0,0.08)",
+              "&:empty": { display: "none" },
             },
-          }}
+          },
+        }}
         filterOptions={(x) => x}
         options={options}
         autoComplete
@@ -137,7 +169,35 @@ export default function SearchBar() {
         noOptionsText={isPending ? "Recherche en cours..." : "Aucun résultat"}
         openOnFocus={false}
         open={inputValue.length > 2}
-        
+        groupBy={(option) =>
+          "titre" in option ? "Dossiers législatifs" : "Député·e·s"
+        }
+        renderGroup={(params) => (
+          <li key={params.key}>
+            <Box
+              sx={{
+                px: 2,
+                py: 0.75,
+                borderBottom: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  fontSize: "0.65rem",
+                  letterSpacing: "0.08em",
+                  color: "text.secondary",
+                }}
+              >
+                {params.group}
+              </Typography>
+            </Box>
+            <ul style={{ padding: 0 }}>{params.children}</ul>
+          </li>
+        )}
         onInputChange={(event, newInputValue) => {
           setInputValue(newInputValue);
         }}
@@ -154,7 +214,7 @@ export default function SearchBar() {
                 boxShadow: "0px 4px 20px rgba(0, 0, 0, 0.08)",
                 "&:hover": {
                   boxShadow: "0px 6px 25px rgba(0, 0, 0, 0.12)",
-                }
+                },
               },
             }}
             fullWidth
@@ -173,20 +233,27 @@ export default function SearchBar() {
           />
         )}
         renderOption={({ key, ...props }, option) => {
-          if (isActeur(option)) {
+          if (isCirconscriptionActeur(option)) {
             return (
-              <li key={key} {...props} style={{ padding: '12px 10px' }}>
+              <li key={key} {...props} style={{ padding: "12px 10px" }}>
                 <ActeurOption {...option} />
               </li>
             );
           }
+          if (isPrismaActeur(option)) {
+            return (
+              <li key={key} {...props} style={{ padding: "12px 10px" }}>
+                <PrismaActeurOption acteur={option} />
+              </li>
+            );
+          }
           return (
-            <li key={key} {...props} style={{ padding: '12px 10px' }}>
+            <li key={key} {...props} style={{ padding: "12px 10px" }}>
               <Link
-                href={`/17/dossier/${option.uid}`}
+                href={`/17/dossier/${(option as Dossier).uid}`}
                 style={{ width: "100%" }}
               >
-                {option.titre}
+                {(option as Dossier).titre}
               </Link>
             </li>
           );
@@ -199,6 +266,7 @@ export default function SearchBar() {
   );
 }
 
+// For location-based results (code4code.eu) — still needs useQuery for slug/urlImage
 export function ActeurOption(props: Circonscription) {
   const { data: acteur } = useQuery({
     queryKey: ["acteur", props.depute.uid],
@@ -225,9 +293,7 @@ export function ActeurOption(props: Circonscription) {
         </Avatar>
         <div style={{ flexGrow: 1 }}>
           <Typography variant="body1" fontWeight="bold">
-            {props.depute.etatCivil.ident.prenom}{" "}
-            {props.depute.etatCivil.ident.nom}
-            
+            {prenom} {nom}
           </Typography>
           <Stack direction="row" spacing={1} justifyContent="space-between">
             {props.circonscription_legislative && (
@@ -241,6 +307,30 @@ export function ActeurOption(props: Circonscription) {
               </Typography>
             )}
           </Stack>
+        </div>
+      </Stack>
+    </Link>
+  );
+}
+
+// For name-based results (internal API) — data already available, no extra query needed
+function PrismaActeurOption({ acteur }: { acteur: Acteur }) {
+  if (!acteur.slug) return null;
+  return (
+    <Link href={`/depute/${acteur.slug}`}>
+      <Stack direction="row" spacing={1.5}>
+        <Avatar
+          sx={{ height: 46, width: 46 }}
+          alt={"photo de " + acteur.prenom + " " + acteur.nom}
+          src={acteur.urlImage ?? ""}
+        >
+          {acteur.prenom?.[0]?.toUpperCase()}
+          {acteur.nom?.[0]?.toUpperCase()}
+        </Avatar>
+        <div style={{ flexGrow: 1 }}>
+          <Typography variant="body1" fontWeight="bold">
+            {acteur.prenom} {acteur.nom}
+          </Typography>
         </div>
       </Stack>
     </Link>

--- a/data/searchActeur.ts
+++ b/data/searchActeur.ts
@@ -1,9 +1,13 @@
-import { Acteur } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+
+export type ActeurWithGroupe = Prisma.ActeurGetPayload<{
+  include: { groupeParlementaire: true };
+}>;
 
 export async function searchActeur(
   search: string,
   perPage = 5
-): Promise<Acteur[]> {
+): Promise<ActeurWithGroupe[]> {
   const params = new URLSearchParams({
     search,
     prefixSearch: "true",
@@ -19,7 +23,7 @@ export async function searchActeur(
       `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/acteurs/?${params}`
     );
     const { data } = await rep.json();
-    return data as Acteur[];
+    return data as ActeurWithGroupe[];
   } catch (error) {
     console.error("Error fetching acteurs by name:", error);
     return [];

--- a/data/searchActeur.ts
+++ b/data/searchActeur.ts
@@ -1,0 +1,27 @@
+import { Acteur } from "@prisma/client";
+
+export async function searchActeur(
+  search: string,
+  perPage = 5
+): Promise<Acteur[]> {
+  const params = new URLSearchParams({
+    search,
+    prefixSearch: "true",
+    chambre: "AN",
+    actif: "true",
+    perPage: String(perPage),
+    searchLanguage: "french",
+    include: "groupeParlementaire",
+  });
+
+  try {
+    const rep = await fetch(
+      `${process.env.NEXT_PUBLIC_TRICOTEUSES_API_URL}/acteurs/?${params}`
+    );
+    const { data } = await rep.json();
+    return data as Acteur[];
+  } catch (error) {
+    console.error("Error fetching acteurs by name:", error);
+    return [];
+  }
+}

--- a/data/searchAmendement.ts
+++ b/data/searchAmendement.ts
@@ -16,7 +16,7 @@ type SearchAmendementParams = {
   sort?: string;
   search?: string;
   sortAmendement?: string;
-  include?: string;
+  include?: string;  
 } & (
   | {
       /**
@@ -96,6 +96,8 @@ export async function searchAmendement(
     page: page.toString(),
     sort,
     chambre: "AN",
+    prefixSearch: "true",
+    searchLanguage: "french",
   });
 
   if (search) {

--- a/data/searchDossier.ts
+++ b/data/searchDossier.ts
@@ -29,7 +29,7 @@ export async function searchDossier(
 ): Promise<PaginatedResponse<Dossier> | null> {
   const {
     perPage = 10,
-    page = 0,
+    page = 1,
     sort = "dateDernierActe.desc",
     search = "",
     codeProcedure = "",

--- a/data/searchDossier.ts
+++ b/data/searchDossier.ts
@@ -42,6 +42,8 @@ export async function searchDossier(
     page: page.toString(),
     sort,
     dataset: "17",
+    prefixSearch: "true",
+    searchLanguage: "french",
   });
 
   Object.entries({


### PR DESCRIPTION

- Remplace la recherche code4code.eu (localisation) par une recherche
  par nom via l'API interne avec prefixSearch=true et searchLanguage=french
- Ajoute data/searchActeur.ts pour la recherche de députés actifs (AN)
  avec inclusion du groupe parlementaire (include=groupeParlementaire)
- Ajoute prefixSearch=true sur la recherche de dossiers
- UI groupée: sections "Député·e·s" / "Dossiers législatifs"
- Affiche le groupe parlementaire sous le nom du député
- Icônes des dossiers remplacées par abréviations en cercle
- Corrige le re-déclenchement du search à la sélection d'une option
- Supprime le flash "Aucun résultat" pendant la recherche en cours

C'est salement claudé ^^

Ca rend comme ça:
<img width="946" height="805" alt="Screenshot 2026-03-02 at 22 34 48" src="https://github.com/user-attachments/assets/e78c7a62-5865-45e9-92dc-a3a6a3b04377" />
